### PR TITLE
Make built_year nullable for inquiry samples

### DIFF
--- a/src/FunderMaps.Core/Entities/InquirySample.cs
+++ b/src/FunderMaps.Core/Entities/InquirySample.cs
@@ -49,8 +49,7 @@ namespace FunderMaps.Core.Entities
         /// <summary>
         ///     Built year.
         /// </summary>
-        [Required]
-        public DateTime BuiltYear { get; set; }
+        public DateTime? BuiltYear { get; set; }
 
         /// <summary>
         ///     Substructure.

--- a/src/FunderMaps.Data/Repositories/InquirySampleRepository.cs
+++ b/src/FunderMaps.Data/Repositories/InquirySampleRepository.cs
@@ -301,7 +301,7 @@ namespace FunderMaps.Data.Repositories
                 UpdateDate = reader.GetSafeDateTime(offset + 5),
                 DeleteDate = reader.GetSafeDateTime(offset + 6),
                 BaseMeasurementLevel = reader.GetFieldValue<BaseMeasurementLevel>(offset + 7),
-                BuiltYear = reader.GetDateTime(offset + 8),
+                BuiltYear = reader.GetSafeDateTime(offset + 8),
                 Substructure = reader.GetFieldValue<Substructure?>(offset + 9),
                 OverallQuality = reader.GetFieldValue<FoundationQuality?>(offset + 10),
                 WoodQuality = reader.GetFieldValue<WoodQuality?>(offset + 11),

--- a/src/FunderMaps.WebApi/DataTransferObjects/InquirySampleDto.cs
+++ b/src/FunderMaps.WebApi/DataTransferObjects/InquirySampleDto.cs
@@ -35,8 +35,7 @@ namespace FunderMaps.WebApi.DataTransferObjects
         /// <summary>
         ///     Built year.
         /// </summary>
-        [Required]
-        public DateTime BuiltYear { get; set; }
+        public DateTime? BuiltYear { get; set; }
 
         /// <summary>
         ///     Substructure.


### PR DESCRIPTION
### Merge when:

* [ ] The merge build succeeded
* [ ] The PR has been reviewed and is approved
* [ ] All packages are upgraded to the latest version (only PR into master)

**What issue does this PR address?**

Fixes #388 

**Does this PR introduce a breaking change?**

Yes, database column report.inquiry_sample.built_year needs to have it's 'not null' flag removed.

**Additional information**:

Remove branch after merge
