### PR TITLE
refactor(auth): drop plaintext fallback in API key lookup

### DIFF
--- a/src/FunderMaps.Data/Repositories/UserRepository.cs
+++ b/src/FunderMaps.Data/Repositories/UserRepository.cs
@@ -106,12 +106,6 @@ internal class UserRepository : DbServiceBase, IUserRepository
     {
         await using var connection = DbContextFactory.DbProvider.ConnectionScope();
 
-        // Hash-first lookup. Every existing key was backfilled into
-        // application.auth_key.key_hash and new keys (issued via the
-        // TS API management route) dual-write both columns. The
-        // plaintext fallback below is defense-in-depth — should never
-        // hit, but keeps customer auth working if some rogue write
-        // path ever leaves key_hash NULL.
         var keyHash = Sha256Hex(key);
         var user = await connection.QuerySingleOrDefaultAsync<User>(@"
             SELECT  -- User
@@ -126,23 +120,6 @@ internal class UserRepository : DbServiceBase, IUserRepository
             JOIN    application.auth_key ak ON ak.user_id = u.id
             WHERE   ak.key_hash = @keyHash
             LIMIT   1", new { keyHash });
-
-        if (user is null)
-        {
-            user = await connection.QuerySingleOrDefaultAsync<User>(@"
-                SELECT  -- User
-                        u.id,
-                        u.given_name,
-                        u.last_name,
-                        u.email,
-                        u.job_title,
-                        u.phone_number,
-                        u.role
-                FROM    application.user AS u
-                JOIN    application.auth_key ak ON ak.user_id = u.id
-                WHERE   ak.key = @key
-                LIMIT   1", new { key });
-        }
 
         return user ?? throw new EntityNotFoundException(nameof(User));
     }


### PR DESCRIPTION
## Summary
- Removes the plaintext-fallback branch from `UserRepository.GetByAuthKeyAsync` — hash-only, matching TS API + TS Webservice
- `Sha256Hex` helper kept (still computes the hash for the lookup)
- Unblocks dropping `application.auth_key.key` in a follow-up PR

## Why now
Phase 4 of the API key hashing migration (deployed 2026-04-25) verified end-to-end that the hash-first path handles 100% of production traffic — the corruption test (insert key K1 + hash H1, overwrite plaintext column with garbage, send K1 to `ws.fundermaps.com` → 200) proved the hash branch is doing the auth, not the plaintext fallback. With four codebases (TS API, TS Webservice, C# Webservice, backfill script) in agreement and every existing key backfilled, the fallback is now dead defense-in-depth code that just blocks the next migration step.

## Test plan
- [x] `podman build --build-arg subtool=FunderMaps.Webservice` — clean
- [x] `podman build --build-arg subtool=FunderMaps.WebApi` — clean
- [ ] CI "Build & Test" passes
- [ ] Post-deploy: send a known-good API key to `ws.fundermaps.com` → 200 (sanity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)