### PR TITLE
chore(types): drop ApplicationRole.Service

### DIFF
--- a/src/FunderMaps.Core/Types/ApplicationRole.cs
+++ b/src/FunderMaps.Core/Types/ApplicationRole.cs
@@ -14,9 +14,4 @@ public enum ApplicationRole
     ///     User.
     /// </summary>
     User = 1,
-
-    /// <summary>
-    ///     Service.
-    /// </summary>
-    Service = 2,
 }

--- a/tests/FunderMaps.Webservice.Tests/FunderMapsWebApplicationFactory.cs
+++ b/tests/FunderMaps.Webservice.Tests/FunderMapsWebApplicationFactory.cs
@@ -127,7 +127,7 @@ internal class MemoryUserRepository : MemoryRepositoryBase<UserExtended, Guid>, 
             Email = "service@contoso.com",
             JobTitle = "Service Account",
             PhoneNumber = "+31612345678",
-            Role = ApplicationRole.Service,
+            Role = ApplicationRole.User,
             PasswordHash = passwordHasher.HashPassword("fundermaps"),
             AuthKey = "fmsk.k0hEiTT0vDBvEqFHItz6wg0U6ejxceDW",
         });


### PR DESCRIPTION
Never used at runtime — 0 rows in application.user have role = 'service'. The matching DB enum value is dropped in the paired FunderMapsWorker migration
sql/migrate/drop_role_service_enum_value.sql.

Npgsql MapEnum is lazy, so the order between this code change and the DB migration doesn't matter; both should land before the next major C# Webservice deploy.

### Merge when:

* [ ] The merge build succeeded
* [ ] The PR has been reviewed and is approved
* [ ] All packages are upgraded to the latest version (only PR into master)

### What issue does this PR address?

Fixes [issue_id]

### Does this PR introduce a breaking change?

Yes/No

### Additional information

* [x] Remove branch after merge (only features into develop)
