### PR TITLE
chore: fix broken dev tooling and dead CI/doc references

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -55,29 +55,3 @@ jobs:
         Authentication__Cookie__Domain: localhost
         DataProtection__ApplicationName: FunderMapsTest
         ConnectionStrings__FunderMapsConnection: "Server=localhost;Database=fundermaps;User Id=fundermaps_webapp"
-
-    # - name: Testing Portal
-    #   run: dotnet test --nologo --configuration ${{ env.BUILD_CONFIG }} --no-restore --filter FunderMaps.IntegrationTests.Portal
-    #   env:
-    #     ASPNETCORE_ENVIRONMENT: Production
-    #     UseExternalServices: False
-    #     Jwt__Issuer: "FunderMapsTest"
-    #     Jwt__Audience: "FunderMapsTest"
-    #     Jwt__TokenValidity: 10
-    #     Jwt__SignatureKey: somelargetextstringusedinsignatures
-    #     Incident__ClientId: 42
-    #     Incident__Recipients__0: info@example.com
-    #     ConnectionStrings__FunderMapsConnection: "Server=localhost;Database=fundermaps;User Id=fundermaps_portal"
-
-    # - name: Testing Webservice
-    #   run: dotnet test --nologo --configuration ${{ env.BUILD_CONFIG }} --no-restore --filter FunderMaps.IntegrationTests.Webservice
-    #   env:
-    #     ASPNETCORE_ENVIRONMENT: Production
-    #     UseExternalServices: False
-    #     Jwt__Issuer: "FunderMapsTest"
-    #     Jwt__Audience: "FunderMapsTest"
-    #     Jwt__TokenValidity: 10
-    #     Jwt__SignatureKey: somelargetextstringusedinsignatures
-    #     Incident__ClientId: 42
-    #     Incident__Recipients__0: info@example.com
-    #     ConnectionStrings__FunderMapsConnection: "Server=localhost;Database=fundermaps;User Id=fundermaps_webservice"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,31 +5,12 @@
             // Use IntelliSense to find out which attributes exist for C# debugging
             // Use hover for the description of the existing attributes
             // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
-            "name": "FunderMaps.WsClient",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/FunderMaps.WsClient/bin/Debug/net8.0/FunderMaps.WsClient.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/src/FunderMaps.WsClient",
-            // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
-            "console": "integratedTerminal",
-            "stopAtEntry": false,
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            }
-        },
-        {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md
             "name": "FunderMaps.Webservice",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/FunderMaps.Webservice/bin/Debug/net8.0/FunderMaps.Webservice.dll",
+            "program": "${workspaceFolder}/src/FunderMaps.Webservice/bin/Debug/net10.0/FunderMaps.Webservice.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/FunderMaps.Webservice",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console
@@ -48,7 +29,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/FunderMaps.WebApi/bin/Debug/net8.0/FunderMaps.WebApi.dll",
+            "program": "${workspaceFolder}/src/FunderMaps.WebApi/bin/Debug/net10.0/FunderMaps.WebApi.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/FunderMaps.WebApi",
             // For more information about the 'console' field, see https://aka.ms/VSCode-CS-LaunchJson-Console

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ When using VS Code the 'debug' section should list all the applications. Just ru
 
 ## Configuration
 
-See the `contrib/etc/_appsettings.{ENV}.json` directory for configuration files for each environment. You can copy these configuration files to the project source directory (`src/{project}`).
+See `contrib/etc/` for the `_appsettings.{ENV}.json` configuration files for each environment. You can copy these configuration files to the project source directory (`src/{project}`).
 
 ## Using the application
 


### PR DESCRIPTION
Conservative dev-tooling/doc hygiene — no production runtime code touched (this is the live C# backend; default branch `develop`).

## Fixed
- **`.vscode/launch.json`** — removed the `FunderMaps.WsClient` debug config (the project no longer exists under `src/`), and fixed the `Webservice` + `WebApi` program paths from `net8.0` → `net10.0`. All `.csproj` target `net10.0`, so F5 debug was pointing at a non-existent DLL.
- **`.github/workflows/dotnet-core.yml`** — removed the two commented-out test jobs targeting `FunderMaps.IntegrationTests.{Portal,Webservice}`; neither project exists. The active `FunderMaps.Webservice.Tests` job is untouched.
- **`README.md`** — `contrib/etc/` is a directory *containing* `_appsettings.{ENV}.json` files, not a "directory" named after the file pattern. Reworded.

## Deliberately left untouched (need your call)
- **`scripts/deploy.sh`** — line 35 does `pushd src/FunderMaps.Worker/`, which moved to the **FunderMapsWorker** repo. The script is broken as-is, but the correct publish target (Webservice? Docker? something else) is a deployment decision, not a mechanical fix — flagging rather than guessing on a prod deploy script.
- **`.github/workflows/codeql-analysis.yml`** — every analysis step (`init`/`autobuild`/`analyze`) is commented out; only `checkout` runs, so it produces a misleading green check. Re-enable vs delete is a CI-policy call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)